### PR TITLE
add information about curl -F option without outer quote #4510

### DIFF
--- a/doc/sphinx-guides/source/api/getting-started.rst
+++ b/doc/sphinx-guides/source/api/getting-started.rst
@@ -52,6 +52,20 @@ If you ever want to check an environment variable, you can "echo" it like this:
 
   echo $SERVER_URL
 
+With curl version 7.56.0 and higher, it is recommended to use --form-string with outer quote rather than -F flag without outer quote.
+
+For example, curl command parameter below might cause error such as ``warning: garbage at end of field specification: ,"categories":["Data"]}``.
+
+.. code-block:: bash
+
+  -F jsonData={\"description\":\"My description.\",\"categories\":[\"Data\"]}
+
+Instead, use --from-string with outer quote. See https://github.com/curl/curl/issues/2022
+
+.. code-block:: bash
+
+  --from-string 'jsonData={"description":"My description.","categories":["Data"]}'
+
 If you don't like curl, don't have curl, or want to use a different programming language, you are encouraged to check out the Python, Javascript, R, and Java options in the :doc:`client-libraries` section.
 
 .. _curl: https://curl.haxx.se


### PR DESCRIPTION
**What this PR does / why we need it**:
Add information about problem with curl -F option without outer quote for curl 7.56.0 and higher versions.
**Which issue(s) this PR closes**:
Closes #4510
https://github.com/IQSS/dataverse/issues/4510
**Special notes for your reviewer**:
None.
**Suggestions on how to test this**:
None.
**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.
**Is there a release notes update needed for this change?**:
No.
**Additional documentation**:
